### PR TITLE
Remove India chapter

### DIFF
--- a/womenwhogo.org/index.html
+++ b/womenwhogo.org/index.html
@@ -239,24 +239,6 @@
         </div>
       </div>
       <br>
-      <div class="row chapter-region">
-        <div class="col-xs-12">
-          <p class="lead text-muted text-capital">India</p>
-        </div>
-      </div>
-      <div class="row chapter">
-        <div class="col-xs-5">
-          <p class="lead">Bangalore:</p>
-        </div>
-        <div class="col-xs-7">
-          <p class="col-xs-2 text-center link">
-            <a href="http://www.meetup.com/Women-Who-Go-Bangalore/" target="_blank">
-              <img src="./assets/images/meetup.png">
-            </a>
-          </p>
-        </div>
-      </div>
-       <br>
        <div class="row chapter-region">
         <div class="col-xs-12">
           <p class="lead text-muted text-capital">Israel</p>


### PR DESCRIPTION
The Indian chapter (WomenWhoGo-Bangalore) was closed down on August 27, 2017 when the organizer stepped down without a replacement. The chapter was never removed from the womenwhogo website though. This PR removes it.

The following is an excerpt from the email that meetup.com had sent:

```
Members of Women Who Go Bangalore,

Your Organizer, Smita, just stepped down without nominating a replacement.

Without an Organizer, Women Who Go Bangalore will shut down on August 27, 2017.

Step up to become this Meetup Group's Organizer and you can guide its future direction!
```

The original meetup link (https://www.meetup.com/Women-Who-Go-Bangalore/) is also no longer active.

I believe the organizer got busy at work and was not able to continue with organizing the meetup. I would have loved to help it carry on but I live in another city (Mumbai) and there are very few gophers in my city, most of them are in Bangalore. :(

/cc @carolynvs since I think you are one of the maintainers of this website :)