### PR TITLE
remove wwg-floripa

### DIFF
--- a/womenwhogo.org/index.html
+++ b/womenwhogo.org/index.html
@@ -96,26 +96,6 @@
         </div>
       </div>
 
-      <br>
-      <div class="row chapter">
-        <div class="col-xs-5">
-          <p class="lead">Florianópolis:</p>
-        </div>
-        <div class="col-xs-7">
-          <p class="col-xs-2 text-center link">
-            <a href="https://www.meetup.com/Women-Who-Go-Floripa/" target="_blank">
-              <img src="./assets/images/meetup.png">
-            </a>
-          </p>
-          <p class="col-xs-2 text-center link">
-            <a href="https://twitter.com/WWGFloripa" target="_blank">
-              <img src="./assets/images/twitter.png">
-            </a>
-          </p>
-        </div>
-      </div>
-      <br>
-
       <div class="row chapter">
         <div class="col-xs-5">
           <p class="lead">Porto Alegre:</p>


### PR DESCRIPTION
The WWG Floripa chapter is no longer active and has been removed from Meetup.com.