### PR TITLE
Upgrade to go 1.11

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,5 @@
 runtime: go
-api_version: go1.9
+api_version: go1.11
 env_variables:
   SLACK_API_TOKEN: '$TOKEN'
 


### PR DESCRIPTION
https://cloud.google.com/appengine/docs/standard/go/config/appref

> Warning: The Go 1.9 runtime version is now deprecated. Starting October 1, 2019, new deployments using this version will not be available. Upgrade your application to use Go 1.11 or Go 1.12 before October 1, 2019.